### PR TITLE
Optimise ./run for webpack

### DIFF
--- a/run
+++ b/run
@@ -272,13 +272,14 @@ update_dependencies() {
     if [ -f package.json ]; then
         package_json_hash=$(${md5_command} package.json | cut -c1-8)
         if [ -d node_modules ]; then
-            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
+            yarn_dependencies_hash=$(find node_modules -type f ! -wholename 'node_modules/.cache/*' -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
         fi
         if [ -z "${yarn_dependencies_hash:-}" ] || [ ! -f .yarn.${project}.hash ] || [ "${yarn_dependencies_hash}" != "$(cat .yarn.${project}.hash)" ]; then
-            echo "Installing new Yarn dependencies"
+            echo "Installing new Yarn dependencies (calculated: ${yarn_dependencies_hash}, saved: $(cat .yarn.${project}.hash))"
             run_as_user "" yarn install --force ${yarn_proxy}
-            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
+            yarn_dependencies_hash=$(find node_modules -type f ! -wholename 'node_modules/.cache/*' -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
             echo ${yarn_dependencies_hash} > .yarn.${project}.hash
+	    echo "Saved: ${yarn_dependencies_hash}"
         else
             echo "Yarn dependencies haven't changed. To force an update, delete .yarn.${project}.hash."
         fi


### PR DESCRIPTION
Make sure ./run doesn't try to reinstall yarn dependencies every time
by ignoring changes in the `node_modules/.cache` folder, which
webpack will update.

QA
--

`./run build`
`./run build` again

Check the second time it says "Yarn dependencies haven't changed."